### PR TITLE
Add support for locations management

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto eol=lf
 
-go.sum linguist-generated=true
+go.sum              linguist-generated=true
+backstage/testdata/ linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,9 @@ jobs:
       run: |
         sleep 30
         go run ./examples/entities/main.go
+    - name: Run locations example
+      env:
+        BACKSTAGE_BASE_URL: http://localhost:${{ job.services.backstage.ports[7000] }}/api
+      run: |
+        sleep 30
+        go run ./examples/locations/main.go

--- a/backstage/entity.go
+++ b/backstage/entity.go
@@ -3,6 +3,7 @@ package backstage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -214,6 +215,10 @@ func (s *entityService) Get(ctx context.Context, uid string) (*Entity, *http.Res
 
 // Delete deletes an orphaned entity by its UID.
 func (s *entityService) Delete(ctx context.Context, uid string) (*http.Response, error) {
+	if uid == "" {
+		return nil, errors.New("uid cannot be empty")
+	}
+
 	path, _ := url.JoinPath(s.apiPath, "/by-uid/", uid)
 	req, _ := s.client.newRequest(http.MethodDelete, path, nil)
 

--- a/backstage/entity_test.go
+++ b/backstage/entity_test.go
@@ -207,7 +207,7 @@ func TestEntityServiceDelete(t *testing.T) {
 	c, _ := NewClient(baseURL.String(), "", nil)
 	s := newEntityService(newCatalogService(c))
 
-	resp, err := s.Delete(context.Background(), "uid")
+	resp, err := s.Delete(context.Background(), uid)
 	assert.NoError(t, err, "Delete should not return an error")
 	assert.NotEmpty(t, resp, "Response should not be empty")
 	assert.EqualValues(t, http.StatusNoContent, resp.StatusCode, "Response status code should match the one from the server")

--- a/backstage/kind_location.go
+++ b/backstage/kind_location.go
@@ -2,7 +2,10 @@ package backstage
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // KindLocation defines name for location kind.
@@ -40,6 +43,26 @@ type LocationEntityV1alpha1 struct {
 	} `json:"spec"`
 }
 
+// LocationCreateResponse defines POST response from location endpoints.
+type LocationCreateResponse struct {
+	// Exists is only set in dryRun mode.
+	Exists bool `json:"exists,omitempty"`
+	// Location contains details of created location.
+	Location *LocationResponse `json:"location,omitempty"`
+	// Entities is a list of entities that were discovered from the created location.
+	Entities []Entity `json:"entities"`
+}
+
+// LocationResponse defines GET response from location endpoints.
+type LocationResponse struct {
+	// ID of the location.
+	ID string `json:"id"`
+	// Type of the location.
+	Type string `json:"type"`
+	// Target of the location.
+	Target string `json:"target"`
+}
+
 // locationService handles communication with the location related methods of the Backstage Catalog API.
 type locationService typedEntityService[LocationEntityV1alpha1]
 
@@ -55,4 +78,49 @@ func newLocationService(s *entityService) *locationService {
 func (s *locationService) Get(ctx context.Context, n string, ns string) (*LocationEntityV1alpha1, *http.Response, error) {
 	cs := (typedEntityService[LocationEntityV1alpha1])(*s)
 	return cs.get(ctx, KindLocation, n, ns)
+}
+
+// Create creates a new location.
+func (s *locationService) Create(ctx context.Context, target string, dryRun bool) (*LocationCreateResponse, *http.Response, error) {
+	if target == "" {
+		return nil, nil, errors.New("target cannot be empty")
+	}
+
+	path, _ := url.JoinPath(s.apiPath, "../locations")
+	req, _ := s.client.newRequest(http.MethodPost, fmt.Sprintf("%s?dryRun=%t", path, dryRun), struct {
+		Target string `json:"target"`
+		Type   string `json:"type"`
+	}{
+		Target: target,
+		Type:   "url",
+	})
+
+	var entity *LocationCreateResponse
+	resp, err := s.client.do(ctx, req, &entity)
+
+	return entity, resp, err
+
+}
+
+// GetByID returns a location identified by its ID.
+func (s *locationService) GetByID(ctx context.Context, id string) (*LocationResponse, *http.Response, error) {
+	path, _ := url.JoinPath(s.apiPath, "../locations", id)
+	req, _ := s.client.newRequest(http.MethodGet, path, nil)
+
+	var entity *LocationResponse
+	resp, err := s.client.do(ctx, req, &entity)
+
+	return entity, resp, err
+}
+
+// DeleteByID deletes a location identified by its ID.
+func (s *locationService) DeleteByID(ctx context.Context, id string) (*http.Response, error) {
+	if id == "" {
+		return nil, errors.New("id cannot be empty")
+	}
+
+	path, _ := url.JoinPath(s.apiPath, "../locations", id)
+	req, _ := s.client.newRequest(http.MethodDelete, path, nil)
+
+	return s.client.do(ctx, req, nil)
 }

--- a/backstage/kind_location.go
+++ b/backstage/kind_location.go
@@ -37,7 +37,7 @@ type LocationEntityV1alpha1 struct {
 		// entity itself.
 		Targets []string `json:"targets,omitempty"`
 
-		// Presence describes whether the presence of the location target is required and it should be considered an error if it
+		// Presence describes whether the presence of the location target is required, and it should be considered an error if it
 		// can not be found.
 		Presence string `json:"presence,omitempty"`
 	} `json:"spec"`
@@ -48,7 +48,7 @@ type LocationCreateResponse struct {
 	// Exists is only set in dryRun mode.
 	Exists bool `json:"exists,omitempty"`
 	// Location contains details of created location.
-	Location *LocationResponse `json:"location,omitempty"`
+	Location LocationResponse `json:"location,omitempty"`
 	// Entities is a list of entities that were discovered from the created location.
 	Entities []Entity `json:"entities"`
 }

--- a/backstage/kind_location.go
+++ b/backstage/kind_location.go
@@ -48,7 +48,7 @@ type LocationCreateResponse struct {
 	// Exists is only set in dryRun mode.
 	Exists bool `json:"exists,omitempty"`
 	// Location contains details of created location.
-	Location LocationResponse `json:"location,omitempty"`
+	Location *LocationResponse `json:"location,omitempty"`
 	// Entities is a list of entities that were discovered from the created location.
 	Entities []Entity `json:"entities"`
 }

--- a/backstage/kind_location.go
+++ b/backstage/kind_location.go
@@ -53,7 +53,7 @@ type LocationCreateResponse struct {
 	Entities []Entity `json:"entities"`
 }
 
-// LocationResponse defines GET response from location endpoints.
+// LocationResponse defines GET response to get single location from location endpoints.
 type LocationResponse struct {
 	// ID of the location.
 	ID string `json:"id"`
@@ -61,6 +61,11 @@ type LocationResponse struct {
 	Type string `json:"type"`
 	// Target of the location.
 	Target string `json:"target"`
+}
+
+// LocationListResponse defines GET response to get all locations from location endpoints.
+type LocationListResponse struct {
+	Data *LocationResponse `json:"data"`
 }
 
 // locationService handles communication with the location related methods of the Backstage Catalog API.
@@ -100,6 +105,17 @@ func (s *locationService) Create(ctx context.Context, target string, dryRun bool
 
 	return entity, resp, err
 
+}
+
+// List returns all locations.
+func (s *locationService) List(ctx context.Context) ([]LocationListResponse, *http.Response, error) {
+	path, _ := url.JoinPath(s.apiPath, "../locations")
+	req, _ := s.client.newRequest(http.MethodGet, path, nil)
+
+	var entities []LocationListResponse
+	resp, err := s.client.do(ctx, req, &entities)
+
+	return entities, resp, err
 }
 
 // GetByID returns a location identified by its ID.

--- a/backstage/kind_location_test.go
+++ b/backstage/kind_location_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"testing"
@@ -42,4 +43,139 @@ func TestKindLocationGet(t *testing.T) {
 	assert.NoError(t, err, "Get should not return an error")
 	assert.NotEmpty(t, resp, "Response should not be empty")
 	assert.EqualValues(t, &expected, actual, "Response body should match the one from the server")
+}
+
+// TestKindLocationCreateByID tests functionality of creating a new location.
+func TestKindLocationCreateByID(t *testing.T) {
+	const dataFile = "testdata/location_create.json"
+	const target = "https://github.com/tdabasinskas/go/backstage/test"
+
+	expected := LocationCreateResponse{}
+	expectedData, _ := os.ReadFile(dataFile)
+	err := json.Unmarshal(expectedData, &expected)
+
+	assert.FileExists(t, dataFile, "Test data file should exist")
+	assert.NoError(t, err, "Unmarshal should not return an error")
+
+	baseURL, _ := url.Parse("https://foo:1234/api")
+	defer gock.Off()
+	gock.New(baseURL.String()).
+		MatchHeader("Accept", "application/json").
+		Post("/catalog/locations").
+		MatchParam("dryRun", "false").
+		Reply(200).
+		JSON(&LocationCreateResponse{
+			Location: &LocationResponse{
+				ID:     "830d2354-8bbb-42d1-a751-2959f6da5416",
+				Type:   "url",
+				Target: target,
+			},
+			Entities: []Entity{},
+		})
+
+	c, _ := NewClient(baseURL.String(), "", nil)
+	s := newLocationService(&entityService{
+		client:  c,
+		apiPath: "/catalog/entities",
+	})
+
+	actual, resp, err := s.Create(context.Background(), target, false)
+	assert.NoError(t, err, "Get should not return an error")
+	assert.NotEmpty(t, resp, "Response should not be empty")
+	assert.EqualValues(t, &expected, actual, "Response body should match the one from the server")
+}
+
+// TestKindLocationCreateByID_DryRun tests functionality of creating a new location.
+func TestKindLocationCreateByID_DryRun(t *testing.T) {
+	const dataFile = "testdata/location_create_dryrun.json"
+	const target = "https://github.com/tdabasinskas/go/backstage/test"
+
+	expected := LocationCreateResponse{}
+	expectedData, _ := os.ReadFile(dataFile)
+	err := json.Unmarshal(expectedData, &expected)
+
+	assert.FileExists(t, dataFile, "Test data file should exist")
+	assert.NoError(t, err, "Unmarshal should not return an error")
+
+	baseURL, _ := url.Parse("https://foo:1234/api")
+	defer gock.Off()
+	gock.New(baseURL.String()).
+		MatchHeader("Accept", "application/json").
+		Post("/catalog/locations").
+		MatchParam("dryRun", "true").
+		Reply(200).
+		JSON(&LocationCreateResponse{
+			Location: &LocationResponse{
+				ID:     "830d2354-8bbb-42d1-a751-2959f6da5416",
+				Type:   "url",
+				Target: target,
+			},
+			Entities: []Entity{},
+		})
+
+	c, _ := NewClient(baseURL.String(), "", nil)
+	s := newLocationService(&entityService{
+		client:  c,
+		apiPath: "/catalog/entities",
+	})
+
+	actual, resp, err := s.Create(context.Background(), target, true)
+	assert.NoError(t, err, "Get should not return an error")
+	assert.NotEmpty(t, resp, "Response should not be empty")
+	assert.EqualValues(t, &expected, actual, "Response body should match the one from the server")
+}
+
+// TestKindLocationGetByID tests functionality of getting a location by its ID.
+func TestKindLocationGetByID(t *testing.T) {
+	const dataFile = "testdata/location_by_id.json"
+	const id = "830d2354-8bbb-42d1-a751-2959f6da5416"
+
+	expected := LocationResponse{}
+	expectedData, _ := os.ReadFile(dataFile)
+	err := json.Unmarshal(expectedData, &expected)
+
+	assert.FileExists(t, dataFile, "Test data file should exist")
+	assert.NoError(t, err, "Unmarshal should not return an error")
+
+	baseURL, _ := url.Parse("https://foo:1234/api")
+	defer gock.Off()
+	gock.New(baseURL.String()).
+		MatchHeader("Accept", "application/json").
+		Get(fmt.Sprintf("/catalog/locations/%s", id)).
+		Reply(200).
+		File(dataFile)
+
+	c, _ := NewClient(baseURL.String(), "", nil)
+	s := newLocationService(&entityService{
+		client:  c,
+		apiPath: "/catalog/entities",
+	})
+
+	actual, resp, err := s.GetByID(context.Background(), id)
+	assert.NoError(t, err, "Get should not return an error")
+	assert.NotEmpty(t, resp, "Response should not be empty")
+	assert.EqualValues(t, &expected, actual, "Response body should match the one from the server")
+}
+
+// TestEntityServiceDelete tests the deletion of an entity.
+func TestKindLocationDeleteByID(t *testing.T) {
+	const id = "id"
+
+	baseURL, _ := url.Parse("https://foo:1234/api")
+	defer gock.Off()
+	gock.New(baseURL.String()).
+		MatchHeader("Accept", "application/json").
+		Delete(fmt.Sprintf("/catalog/locations/%s", id)).
+		Reply(http.StatusNoContent)
+
+	c, _ := NewClient(baseURL.String(), "", nil)
+	s := newLocationService(&entityService{
+		client:  c,
+		apiPath: "/catalog/entities",
+	})
+
+	resp, err := s.DeleteByID(context.Background(), id)
+	assert.NoError(t, err, "Delete should not return an error")
+	assert.NotEmpty(t, resp, "Response should not be empty")
+	assert.EqualValues(t, http.StatusNoContent, resp.StatusCode, "Response status code should match the one from the server")
 }

--- a/backstage/testdata/catalog-info.yaml
+++ b/backstage/testdata/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  description: |
+    Backstage is an open-source developer portal that puts the developer experience first.
+  annotations:
+    github.com/project-slug: backstage/backstage
+    backstage.io/techdocs-ref: dir:.
+    lighthouse.com/website-url: https://backstage.io
+spec:
+  type: library
+  owner: CNCF
+  lifecycle: experimental

--- a/backstage/testdata/location_by_id.json
+++ b/backstage/testdata/location_by_id.json
@@ -1,0 +1,5 @@
+{
+  "id": "830d2354-8bbb-42d1-a751-2959f6da5416",
+  "type": "url",
+  "target": "https://github.com/tdabasinskas/go/backstage/test"
+}

--- a/backstage/testdata/location_create.json
+++ b/backstage/testdata/location_create.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "id": "830d2354-8bbb-42d1-a751-2959f6da5416",
+    "type": "url",
+    "target": "https://github.com/tdabasinskas/go/backstage/test"
+  },
+  "entities": []
+}

--- a/backstage/testdata/location_create_dryrun.json
+++ b/backstage/testdata/location_create_dryrun.json
@@ -1,0 +1,9 @@
+{
+  "exists": false,
+  "location": {
+    "id": "830d2354-8bbb-42d1-a751-2959f6da5416",
+    "type": "url",
+    "target": "https://github.com/tdabasinskas/go/backstage/test"
+  },
+  "entities": []
+}

--- a/backstage/testdata/locations.json
+++ b/backstage/testdata/locations.json
@@ -1,0 +1,16 @@
+[
+  {
+    "data": {
+      "id": "650a7ec5-9813-4f42-ae8a-cde84653daf4",
+      "target": "https://github.com/tdabasinskas/test",
+      "type": "url"
+    }
+  },
+  {
+    "data": {
+      "id": "ab31518c-91a4-49b8-a65a-3a12c7f92055",
+      "target": "https://github.com/tdabasinskas/example",
+      "type": "url"
+    }
+  }
+]

--- a/examples/locations/go.mod
+++ b/examples/locations/go.mod
@@ -1,0 +1,7 @@
+module examplelocations
+
+go 1.19
+
+replace github.com/tdabasinskas/go-backstage => ../..
+
+require github.com/tdabasinskas/go-backstage v0.0.0-20230117064629-2a4ac9398d92

--- a/examples/locations/main.go
+++ b/examples/locations/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/tdabasinskas/go-backstage/backstage"
+)
+
+func main() {
+	const locationTarget = "https://github.com/tdabasinskas/backstage-go/test"
+
+	baseURL, ok := os.LookupEnv("BACKSTAGE_BASE_URL")
+	if !ok {
+		baseURL = "http://localhost:7007/api/"
+	}
+
+	log.Println("Initializing Backstage client...")
+	c, _ := backstage.NewClient(baseURL, "default", nil)
+
+	log.Println("Creating new location in a dry-run mode...")
+	if location, _, err := c.Catalog.Locations.Create(context.Background(), locationTarget, false); err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("Location to be created: %v", location)
+	}
+
+	log.Println("Creating new location...")
+	created, _, err := c.Catalog.Locations.Create(context.Background(), locationTarget, true)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("Location created: %v", created)
+	}
+
+	log.Println("Getting created location...")
+	if location, _, err := c.Catalog.Locations.GetByID(context.Background(), created.Location.ID); err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("Retrieved created location: %v", location)
+	}
+
+	log.Println("Listing all locations...")
+	if locations, _, err := c.Catalog.Locations.List(context.Background()); err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("Locations: %v", locations)
+	}
+
+	log.Println("Deleting location..")
+	if resp, err := c.Catalog.Locations.DeleteByID(context.Background(), created.Location.ID); err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("Delete response: %v", resp)
+	}
+}

--- a/examples/locations/main.go
+++ b/examples/locations/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/tdabasinskas/go-backstage/backstage"
 )
 
 func main() {
-	const locationTarget = "https://github.com/tdabasinskas/backstage-go/test"
+	const locationTarget = "https://github.com/backstage/backstage/blob/master/catalog-info.yaml"
 
 	baseURL, ok := os.LookupEnv("BACKSTAGE_BASE_URL")
 	if !ok {
@@ -20,18 +21,18 @@ func main() {
 	c, _ := backstage.NewClient(baseURL, "default", nil)
 
 	log.Println("Creating new location in a dry-run mode...")
-	if location, _, err := c.Catalog.Locations.Create(context.Background(), locationTarget, false); err != nil {
+	if location, _, err := c.Catalog.Locations.Create(context.Background(), locationTarget, true); err != nil {
 		log.Fatal(err)
 	} else {
 		log.Printf("Location to be created: %v", location)
 	}
 
 	log.Println("Creating new location...")
-	created, _, err := c.Catalog.Locations.Create(context.Background(), locationTarget, true)
+	created, resp, err := c.Catalog.Locations.Create(context.Background(), locationTarget, false)
 	if err != nil {
 		log.Fatal(err)
 	} else {
-		log.Printf("Location created: %v", created)
+		log.Printf("Location created: %v, %v", created, resp)
 	}
 
 	log.Println("Getting created location...")
@@ -52,6 +53,10 @@ func main() {
 	if resp, err := c.Catalog.Locations.DeleteByID(context.Background(), created.Location.ID); err != nil {
 		log.Fatal(err)
 	} else {
-		log.Printf("Delete response: %v", resp)
+		if resp.StatusCode != http.StatusNoContent {
+			log.Fatalf("Delete not successful: %s", resp.Status)
+		} else {
+			log.Printf("Delete response: %v", resp)
+		}
 	}
 }

--- a/examples/locations/main.go
+++ b/examples/locations/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	const locationTarget = "https://github.com/backstage/backstage/blob/master/catalog-info.yaml"
+	const locationTarget = "https://github.com/tdabasinskas/go-backstage/tree/main/backstage/testdata"
 
 	baseURL, ok := os.LookupEnv("BACKSTAGE_BASE_URL")
 	if !ok {
@@ -28,25 +28,37 @@ func main() {
 	}
 
 	log.Println("Creating new location...")
-	created, resp, err := c.Catalog.Locations.Create(context.Background(), locationTarget, false)
+	created, _, err := c.Catalog.Locations.Create(context.Background(), locationTarget, false)
 	if err != nil {
 		log.Fatal(err)
 	} else {
-		log.Printf("Location created: %v, %v", created, resp)
+		if created.Location.Target != locationTarget {
+			log.Fatalf("Created location target does not match: %v", created.Location.Target)
+		} else {
+			log.Printf("Location created: %v", created)
+		}
 	}
 
 	log.Println("Getting created location...")
 	if location, _, err := c.Catalog.Locations.GetByID(context.Background(), created.Location.ID); err != nil {
 		log.Fatal(err)
 	} else {
-		log.Printf("Retrieved created location: %v", location)
+		if location.Target != locationTarget {
+			log.Fatalf("Retrieved location target does not match: %v", location.Target)
+		} else {
+			log.Printf("Retrieved created location: %v", location)
+		}
 	}
 
 	log.Println("Listing all locations...")
 	if locations, _, err := c.Catalog.Locations.List(context.Background()); err != nil {
 		log.Fatal(err)
 	} else {
-		log.Printf("Locations: %v", locations)
+		if len(locations) == 0 {
+			log.Fatal("No locations found")
+		} else {
+			log.Printf("Locations: %v", locations)
+		}
 	}
 
 	log.Println("Deleting location..")


### PR DESCRIPTION
Even it's not covered by [the official documentation](https://backstage.io/docs/features/software-catalog/software-catalog-api#locations), it's possible to LIST/GET/CREATE/DELETE locations via `/catalog/location` API endpoint as per [this code](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/service/createRouter.ts#L199-L239).