### PR TITLE
Refactor filtering implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the low-level details of making HTTP requests and parsing responses, allowing de
 With Go installed, run the following to add the package to your project, along with its dependencies:
 
 ```bash
-go get github.com/tdabasinskas/go-backstage/v2@v2
+go get github.com/tdabasinskas/go-backstage/v2
 ```
 
 Alternatively, you can add import the package as following and run `go get` to install it:

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ the low-level details of making HTTP requests and parsing responses, allowing de
 With Go installed, run the following to add the package to your project, along with its dependencies:
 
 ```bash
-go get github.com/tdabasinskas/go-backstage@v1
+go get github.com/tdabasinskas/go-backstage/v2@v2
 ```
 
 Alternatively, you can add import the package as following and run `go get` to install it:
 
 ```go
-import "github.com/tdabasinskas/go-backstage"
+import "github.com/tdabasinskas/go-backstage/v2"
 ```
 
 ## Usage
@@ -29,7 +29,7 @@ import "github.com/tdabasinskas/go-backstage"
 Add the package to your project as following:
 
 ```go
-import "github.com/tdabasinskas/go-backstage"
+import "github.com/tdabasinskas/go-backstage/v2"
 ```
 
 Once imported, create a new Backstage API client to access different parts of Backstage API:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The client than can be used to access different parts of the API, e.g. get the l
 
 ```go
 entities, response, err := c.Catalog.Entities.s.List(context.Background(), &ListEntityOptions{
-        Filters: ListEntityFilter{},
+        Filters: []string{},
         Fields:  []string{},
         Order:   []ListEntityOrder{{ Direction: OrderDescending, Field: "metadata.name" },
     },

--- a/backstage/entity_test.go
+++ b/backstage/entity_test.go
@@ -96,9 +96,7 @@ func TestEntityServiceList_Filter(t *testing.T) {
 	s := newEntityService(newCatalogService(c))
 
 	actual, resp, err := s.List(context.Background(), &ListEntityOptions{
-		Filters: ListEntityFilter{
-			"kind": "User",
-		},
+		Filters: []string{"kind=User"},
 	})
 	assert.NoError(t, err, "Get should not return an error")
 	assert.NotEmpty(t, resp, "Response should not be empty")
@@ -129,7 +127,6 @@ func TestEntityServiceList_Fields(t *testing.T) {
 	s := newEntityService(newCatalogService(c))
 
 	actual, resp, err := s.List(context.Background(), &ListEntityOptions{
-		Filters: ListEntityFilter{},
 		Fields: []string{
 			"metadata.name",
 		},
@@ -163,7 +160,6 @@ func TestEntityServiceList_Order(t *testing.T) {
 	s := newEntityService(newCatalogService(c))
 
 	actual, resp, err := s.List(context.Background(), &ListEntityOptions{
-		Filters: ListEntityFilter{},
 		Order: []ListEntityOrder{
 			{
 				Direction: OrderDescending,
@@ -182,7 +178,6 @@ func TestEntityServiceList_InvalidOrder(t *testing.T) {
 	s := newEntityService(newCatalogService(c))
 
 	_, _, err := s.List(context.Background(), &ListEntityOptions{
-		Filters: ListEntityFilter{},
 		Order: []ListEntityOrder{
 			{
 				Direction: "InvalidOrder",
@@ -211,51 +206,6 @@ func TestEntityServiceDelete(t *testing.T) {
 	assert.NoError(t, err, "Delete should not return an error")
 	assert.NotEmpty(t, resp, "Response should not be empty")
 	assert.EqualValues(t, http.StatusNoContent, resp.StatusCode, "Response status code should match the one from the server")
-}
-
-// TestListEntityFilterString tests if list entity filter string is correctly generated.
-func TestListEntityFilterString(t *testing.T) {
-	tests := []struct {
-		name     string
-		filter   ListEntityFilter
-		expected string
-	}{
-		{
-			name:     "empty filter",
-			filter:   ListEntityFilter{},
-			expected: "",
-		},
-		{
-			name: "filter with one key-value pair",
-			filter: ListEntityFilter{
-				"key1": "value1",
-			},
-			expected: "key1=value1",
-		},
-		{
-			name: "filter with one key and no value",
-			filter: ListEntityFilter{
-				"key1": "",
-			},
-			expected: "key1",
-		},
-		{
-			name: "filter with multiple key-value pairs",
-			filter: ListEntityFilter{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "",
-			},
-			expected: "key1=value1,key2=value2,key3",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual := test.filter.string()
-			assert.Equal(t, test.expected, actual, "List entity filter string should match expected value")
-		})
-	}
 }
 
 // TestListEntityOrderString tests if list entity order string is correctly generated.

--- a/examples/entities/go.mod
+++ b/examples/entities/go.mod
@@ -2,6 +2,6 @@ module exampleentities
 
 go 1.20
 
-replace github.com/tdabasinskas/go-backstage => ../..
+replace github.com/tdabasinskas/go-backstage/v2 => ../..
 
-require github.com/tdabasinskas/go-backstage v0.0.0-20230117064629-2a4ac9398d92
+require github.com/tdabasinskas/go-backstage/v2 v2.0.0-preview.1

--- a/examples/entities/go.mod
+++ b/examples/entities/go.mod
@@ -4,4 +4,4 @@ go 1.20
 
 replace github.com/tdabasinskas/go-backstage/v2 => ../..
 
-require github.com/tdabasinskas/go-backstage/v2 v2.0.0-preview.1
+require github.com/tdabasinskas/go-backstage/v2 v2.0.0-preview.2

--- a/examples/entities/go.sum
+++ b/examples/entities/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/h2non/gock v1.2.0 h1:K6ol8rfrRkUOefooBC8elXoaNGYkpp7y2qcxGG6BzUE=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/entities/main.go
+++ b/examples/entities/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"context"
+	"github.com/tdabasinskas/go-backstage/v2/backstage"
 	"log"
 	"os"
-
-	"github.com/tdabasinskas/go-backstage/backstage"
 )
 
 func main() {

--- a/examples/entities/main.go
+++ b/examples/entities/main.go
@@ -26,13 +26,24 @@ func main() {
 
 	log.Println("Getting component entities...")
 	if entities, _, err := c.Catalog.Entities.List(context.Background(), &backstage.ListEntityOptions{
-		Filters: backstage.ListEntityFilter{
-			"kind": "component",
-		},
+		Filters: []string{"kind=component"},
 	}); err != nil {
 		log.Fatal(err)
 	} else {
 		log.Printf("Component entities: %v", entities)
+	}
+
+	log.Println("Getting location, API and component entities...")
+	if entities, _, err := c.Catalog.Entities.List(context.Background(), &backstage.ListEntityOptions{
+		Filters: []string{
+			"kind=component",
+			"kind=location",
+			"kind=api",
+		},
+	}); err != nil {
+		log.Fatal(err)
+	} else {
+		log.Printf("Component, location and API entities: %v", entities)
 	}
 
 	log.Println("Getting specific component entity by UID...")

--- a/examples/locations/go.mod
+++ b/examples/locations/go.mod
@@ -2,6 +2,6 @@ module examplelocations
 
 go 1.20
 
-replace github.com/tdabasinskas/go-backstage => ../..
+replace github.com/tdabasinskas/go-backstage/v2 => ../..
 
-require github.com/tdabasinskas/go-backstage v0.0.0-20230117064629-2a4ac9398d92
+require github.com/tdabasinskas/go-backstage/v2 v2.0.0-preview.2

--- a/examples/locations/main.go
+++ b/examples/locations/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/tdabasinskas/go-backstage/backstage"
+	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tdabasinskas/go-backstage
+module github.com/tdabasinskas/go-backstage/v2
 
 go 1.20
 


### PR DESCRIPTION
Refactor filtering implementation to resolve #6.

We couldn't continue using `map`, as it does not allow filtering on multiple values of the same field (i.e., use `OR`) as per [documentation](https://backstage.io/docs/features/software-catalog/software-catalog-api/#filtering).