### PR TITLE
add yaml annotations on struct fields

### DIFF
--- a/backstage/entity.go
+++ b/backstage/entity.go
@@ -13,22 +13,22 @@ import (
 // https://github.com/backstage/backstage/blob/master/packages/catalog-model/src/schema/Entity.schema.json
 type Entity struct {
 	// ApiVersion is the version of specification format for this particular entity that this is written against.
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is the high level entity type being described.
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Metadata is metadata related to the entity. Should always be "System".
-	Metadata EntityMeta `json:"metadata"`
+	Metadata EntityMeta `json:"metadata" yaml:"metadata"`
 
 	// Spec is the specification data describing the entity itself.
-	Spec map[string]interface{} `json:"spec,omitempty"`
+	Spec map[string]interface{} `json:"spec,omitempty" yaml:"spec,omitempty"`
 
 	// Relations that this entity has with other entities.
-	Relations []EntityRelation `json:"relations,omitempty"`
+	Relations []EntityRelation `json:"relations,omitempty" yaml:"relations,omitempty"`
 
 	// The current status of the entity, as claimed by various sources.
-	Status *EntityStatus `json:"status,omitempty"`
+	Status *EntityStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // EntityMeta represents metadata fields common to all versions/kinds of entity.
@@ -36,119 +36,119 @@ type Entity struct {
 type EntityMeta struct {
 	// UID A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject
 	// an attempt to do so. The field will be populated in read operations.
-	UID string `json:"uid,omitempty"`
+	UID string `json:"uid,omitempty" yaml:"uid,omitempty"`
 
 	// Etag is an opaque string that changes for each update operation to any part of the entity, including metadata. This field
 	// can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read
 	// operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject
 	// the operation if it does not match the current stored value.
-	Etag string `json:"etag,omitempty"`
+	Etag string `json:"etag,omitempty" yaml:"etag,omitempty"`
 
 	// Name of the entity. Must be unique within the catalog at any given point in time, for any given namespace + kind pair.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Namespace that the entity belongs to.
-	Namespace string `json:"namespace,omitempty"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 
 	// Title is a display name of the entity, to be presented in user interfaces instead of the name property, when available.
-	Title string `json:"title,omitempty"`
+	Title string `json:"title,omitempty" yaml:"title,omitempty"`
 
 	// Description is a short (typically relatively few words, on one line) description of the entity.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// Labels are key/value pairs of identifying information attached to the entity.
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 
 	// Annotations are key/value pairs of non-identifying auxiliary information attached to the entity.
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 
 	// Tags is a list of single-valued strings, to for example classify catalog entities in various ways.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Links is a list of external hyperlinks related to the entity. Links can provide additional contextual
 	// information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page.
-	Links []EntityLink `json:"links,omitempty"`
+	Links []EntityLink `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // EntityLink represents a link to external information that is related to the entity.
 // https://github.com/backstage/backstage/blob/master/packages/catalog-model/src/schema/EntityMeta.schema.json
 type EntityLink struct {
 	// URL in a standard uri format.
-	URL string `json:"url"`
+	URL string `json:"url" yaml:"url"`
 
 	// Title is a user-friendly display name for the link.
-	Title string `json:"title,omitempty"`
+	Title string `json:"title,omitempty" yaml:"title,omitempty"`
 
 	// Icon is a key representing a visual icon to be displayed in the UI.
-	Icon string `json:"icon,omitempty"`
+	Icon string `json:"icon,omitempty" yaml:"icon,omitempty"`
 
 	// Type is an optional value to categorize links into specific groups.
-	Type string `json:"type,omitempty"`
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
 // EntityRelation is a directed relation from one entity to another.
 // https://github.com/backstage/backstage/blob/master/packages/catalog-model/src/schema/shared/common.schema.json
 type EntityRelation struct {
 	// Type of the relation.
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// TargetRef is the entity ref of the target of this relation.
-	TargetRef string `json:"targetRef"`
+	TargetRef string `json:"targetRef" yaml:"targetRef"`
 
 	// Target is the entity of the target of this relation.
-	Target EntityRelationTarget `json:"target"`
+	Target EntityRelationTarget `json:"target" yaml:"target"`
 }
 
 // EntityRelationTarget describes the target of an entity relation.
 type EntityRelationTarget struct {
 	// Name of the target entity. Must be unique within the catalog at any given point in time, for any given namespace + kind pair.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Kind is the high level target entity type being described.
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Namespace that the target entity belongs to.
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace" yaml:"namespace"`
 }
 
 // EntityStatus informs current status of the entity, as claimed by various sources.
 // https://github.com/backstage/backstage/blob/master/packages/catalog-model/src/schema/shared/common.schema.json
 type EntityStatus struct {
 	// A specific status item on a well known format.
-	Items []EntityStatusItem `json:"items,omitempty"`
+	Items []EntityStatusItem `json:"items,omitempty" yaml:"items,omitempty"`
 }
 
 // EntityStatusItem contains a specific status item on a well known format.
 // https://github.com/backstage/backstage/blob/master/packages/catalog-model/src/schema/shared/common.schema.json
 type EntityStatusItem struct {
 	// The item type
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// The status level / severity of the status item.
 	// Either ["info", "warning", "error"]
-	Level string `json:"level"`
+	Level string `json:"level" yaml:"level"`
 
 	// A brief message describing the status, intended for human consumption.
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 
 	// An optional serialized error object related to the status.
-	Error *EntityStatusItemError `json:"error"`
+	Error *EntityStatusItemError `json:"error" yaml:"error"`
 }
 
 // EntityStatusItemError has aA serialized error object.
 // https://github.com/backstage/backstage/blob/master/packages/catalog-model/src/schema/shared/common.schema.json
 type EntityStatusItemError struct {
 	// The type name of the error"
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// The message of the error
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 
 	// An error code associated with the error
-	Code *string `json:"code"`
+	Code *string `json:"code" yaml:"code"`
 
 	// An error stack trace
-	Stack *string `json:"stack"`
+	Stack *string `json:"stack" yaml:"stack"`
 }
 
 // ListEntityOrder defines a condition that can be used to order entities.

--- a/backstage/kind_api.go
+++ b/backstage/kind_api.go
@@ -15,31 +15,31 @@ type ApiEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "API".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the API itself.
-	Spec *ApiEntityV1alpha1Spec `json:"spec"`
+	Spec *ApiEntityV1alpha1Spec `json:"spec" yaml:"spec"`
 }
 
 // ApiEntityV1alpha1Spec describes the specification data describing the API itself.
 type ApiEntityV1alpha1Spec struct {
 	// Type of the API definition.
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// Lifecycle state of the API.
-	Lifecycle string `json:"lifecycle"`
+	Lifecycle string `json:"lifecycle" yaml:"lifecycle"`
 
 	// Owner is entity reference to the owner of the API.
-	Owner string `json:"owner"`
+	Owner string `json:"owner" yaml:"owner"`
 
 	// Definition of the API, based on the format defined by the type.
-	Definition string `json:"definition"`
+	Definition string `json:"definition" yaml:"definition"`
 
 	// System is entity reference to the system that the API belongs to.
-	System string `json:"system,omitempty"`
+	System string `json:"system,omitempty" yaml:"system,omitempty"`
 }
 
 // apiService handles communication with the API related methods of the Backstage Catalog API.

--- a/backstage/kind_component.go
+++ b/backstage/kind_component.go
@@ -15,40 +15,40 @@ type ComponentEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "Component".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the component itself.
-	Spec *ComponentEntityV1alpha1Spec `json:"spec"`
+	Spec *ComponentEntityV1alpha1Spec `json:"spec"  yaml:"spec"`
 }
 
 // ComponentEntityV1alpha1Spec describes the specification data describing the component itself.
 type ComponentEntityV1alpha1Spec struct {
 	// Type of component.
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// Lifecycle state of the component.
-	Lifecycle string `json:"lifecycle"`
+	Lifecycle string `json:"lifecycle" yaml:"lifecycle"`
 
 	// Owner is an entity reference to the owner of the component.
-	Owner string `json:"owner"`
+	Owner string `json:"owner" yaml:"owner"`
 
 	// SubcomponentOf is an entity reference to another component of which the component is a part.
-	SubcomponentOf string `json:"subcomponentOf,omitempty"`
+	SubcomponentOf string `json:"subcomponentOf,omitempty" yaml:"subcomponentOf,omitempty"`
 
 	// ProvidesApis is an array of entity references to the APIs that are provided by the component.
-	ProvidesApis []string `json:"providesApis,omitempty"`
+	ProvidesApis []string `json:"providesApis,omitempty" yaml:"providesApis,omitempty"`
 
 	// ConsumesApis is an array of entity references to the APIs that are consumed by the component.
-	ConsumesApis []string `json:"consumesApis,omitempty"`
+	ConsumesApis []string `json:"consumesApis,omitempty" yaml:"onsumesApis,omitempty"`
 
 	// DependsOn is an array of entity references to the components and resources that the component depends on.
-	DependsOn []string `json:"dependsOn,omitempty"`
+	DependsOn []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty"`
 
 	// System is an array of references to other entities that the component depends on to function.
-	System string `json:"system,omitempty"`
+	System string `json:"system,omitempty" yaml:"system,omitempty"`
 }
 
 // componentService handles communication with the component related methods of the Backstage Catalog API.

--- a/backstage/kind_domain.go
+++ b/backstage/kind_domain.go
@@ -15,19 +15,19 @@ type DomainEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "Domain".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the domain itself.
-	Spec *DomainEntityV1alpha1Spec `json:"spec"`
+	Spec *DomainEntityV1alpha1Spec `json:"spec" yaml:"spec"`
 }
 
 // DomainEntityV1alpha1Spec describes the specification data describing the domain itself.
 type DomainEntityV1alpha1Spec struct {
 	// Owner is an entity reference to the owner of the component.
-	Owner string `json:"owner"`
+	Owner string `json:"owner" yaml:"owner"`
 }
 
 // domainService handles communication with the domain related methods of the Backstage Catalog API.

--- a/backstage/kind_group.go
+++ b/backstage/kind_group.go
@@ -15,20 +15,20 @@ type GroupEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "Group".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the group itself.
-	Spec *GroupEntityV1alpha1Spec `json:"spec"`
+	Spec *GroupEntityV1alpha1Spec `json:"spec" yaml:"spec"`
 }
 
 // GroupEntityV1alpha1Spec describes the specification data describing the group itself.
 type GroupEntityV1alpha1Spec struct {
 	// Type of group. There is currently no enforced set of values for this field, so it is left up to the adopting
 	// organization to choose a nomenclature that matches their org hierarchy.
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// Profile information about the group, mainly for display purposes. All fields of this structure are also optional.
 	// The email would be a group email of some form, that the group may wish to be used for contacting them.
@@ -36,26 +36,26 @@ type GroupEntityV1alpha1Spec struct {
 	// fetch and render on a group page or similar.
 	Profile struct {
 		// DisplayName to present to users.
-		DisplayName string `json:"displayName,omitempty"`
+		DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 
 		// Email where this entity can be reached.
-		Email string `json:"email,omitempty"`
+		Email string `json:"email,omitempty" yaml:"email,omitempty"`
 
 		// Picture is a URL of an image that represents this entity.
-		Picture string `json:"picture,omitempty"`
-	} `json:"profile,omitempty"`
+		Picture string `json:"picture,omitempty" yaml:"picture,omitempty"`
+	} `json:"profile,omitempty" yaml:"profile,omitempty"`
 
 	// Parent is the immediate parent group in the hierarchy, if any. Not all groups must have a parent; the catalog supports
 	// multi-root hierarchies. Groups may however not have more than one parent. This field is an entity reference.
-	Parent string `json:"parent,omitempty"`
+	Parent string `json:"parent,omitempty" yaml:"parent,omitempty"`
 
 	// Children contains immediate child groups of this group in the hierarchy (whose parent field points to this group).
 	// The list must be present, but may be empty if there are no child groups. The items are not guaranteed to be ordered in
 	// any particular way. The entries of this array are entity references.
-	Children []string `json:"children"`
+	Children []string `json:"children" yaml:"children"`
 
 	// Members contains users that are members of this group. The entries of this array are entity references.
-	Members []string `json:"members,omitempty"`
+	Members []string `json:"members,omitempty" yaml:"members,omitempty"`
 }
 
 // groupService handles communication with the group related methods of the Backstage Catalog API.

--- a/backstage/kind_location.go
+++ b/backstage/kind_location.go
@@ -17,58 +17,58 @@ type LocationEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "Location".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the location itself.
-	Spec *LocationEntityV1alpha1Spec `json:"spec"`
+	Spec *LocationEntityV1alpha1Spec `json:"spec" yaml:"spec"`
 }
 
 // LocationEntityV1alpha1Spec describes the specification data describing the location itself.
 type LocationEntityV1alpha1Spec struct {
 	// Type is the single location type, that's common to the targets specified in the spec. If it is left out, it is inherited
 	// from the location type that originally read the entity data.
-	Type string `json:"type,omitempty"`
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 
 	// Target as a string. Can be either an absolute path/URL (depending on the type), or a relative path
 	// such as./details/catalog-info.yaml which is resolved relative to the location of this Location entity itself.
-	Target string `json:"target,omitempty"`
+	Target string `json:"target,omitempty" yaml:"target,omitempty"`
 
 	// Targets contains a list of targets as strings. They can all be either absolute paths/URLs (depending on the type),
 	// or relative paths such as ./details/catalog-info.yaml which are resolved relative to the location of this Location
 	// entity itself.
-	Targets []string `json:"targets,omitempty"`
+	Targets []string `json:"targets,omitempty" yaml:"targets,omitempty"`
 
 	// Presence describes whether the presence of the location target is required, and it should be considered an error if it
 	// can not be found.
-	Presence string `json:"presence,omitempty"`
+	Presence string `json:"presence,omitempty" yaml:"presence,omitempty"`
 }
 
 // LocationCreateResponse defines POST response from location endpoints.
 type LocationCreateResponse struct {
 	// Exists is only set in dryRun mode.
-	Exists bool `json:"exists,omitempty"`
+	Exists bool `json:"exists,omitempty" yaml:"exists,omitempty"`
 	// Location contains details of created location.
-	Location *LocationResponse `json:"location,omitempty"`
+	Location *LocationResponse `json:"location,omitempty" yaml:"location,omitempty"`
 	// Entities is a list of entities that were discovered from the created location.
-	Entities []Entity `json:"entities"`
+	Entities []Entity `json:"entities" yaml:"entities"`
 }
 
 // LocationResponse defines GET response to get single location from location endpoints.
 type LocationResponse struct {
 	// ID of the location.
-	ID string `json:"id"`
+	ID string `json:"id" yaml:"id"`
 	// Type of the location.
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 	// Target of the location.
-	Target string `json:"target"`
+	Target string `json:"target" yaml:"target"`
 }
 
 // LocationListResponse defines GET response to get all locations from location endpoints.
 type LocationListResponse struct {
-	Data *LocationResponse `json:"data"`
+	Data *LocationResponse `json:"data" yaml:"data"`
 }
 
 // locationService handles communication with the location related methods of the Backstage Catalog API.
@@ -96,8 +96,8 @@ func (s *locationService) Create(ctx context.Context, target string, dryRun bool
 
 	path, _ := url.JoinPath(s.apiPath, "../locations")
 	req, _ := s.client.newRequest(http.MethodPost, fmt.Sprintf("%s?dryRun=%t", path, dryRun), struct {
-		Target string `json:"target"`
-		Type   string `json:"type"`
+		Target string `json:"target" yaml:"target"`
+		Type   string `json:"type" yaml:"type"`
 	}{
 		Target: target,
 		Type:   "url",

--- a/backstage/kind_resource.go
+++ b/backstage/kind_resource.go
@@ -15,28 +15,28 @@ type ResourceEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "Resource".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the resource itself.
-	Spec *ResourceEntityV1alpha1Spec `json:"spec"`
+	Spec *ResourceEntityV1alpha1Spec `json:"spec" yaml:"spec"`
 }
 
 // ResourceEntityV1alpha1Spec describes the specification data describing the resource itself.
 type ResourceEntityV1alpha1Spec struct {
 	// Type of resource.
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// Owner is an entity reference to the owner of the resource.
-	Owner string `json:"owner"`
+	Owner string `json:"owner" yaml:"owner"`
 
 	// DependsOn is an array of references to other entities that the resource depends on to function.
-	DependsOn []string `json:"dependsOn,omitempty"`
+	DependsOn []string `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty"`
 
 	// System is an entity reference to the system that the resource belongs to.
-	System string `json:"system,omitempty"`
+	System string `json:"system,omitempty" yaml:"system,omitempty"`
 }
 
 // resourceService handles communication with the resource related methods of the Backstage Catalog API.

--- a/backstage/kind_system.go
+++ b/backstage/kind_system.go
@@ -16,22 +16,22 @@ type SystemEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "System".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the system itself.
-	Spec *SystemEntityV1alpha1Spec `json:"spec"`
+	Spec *SystemEntityV1alpha1Spec `json:"spec" yaml:"spec"`
 }
 
 // SystemEntityV1alpha1Spec describes the specification data describing the system itself.
 type SystemEntityV1alpha1Spec struct {
 	// Owner is an entity reference to the owner of the system.
-	Owner string `json:"owner"`
+	Owner string `json:"owner" yaml:"owner"`
 
 	// Domain is an entity reference to the domain that the system belongs to.
-	Domain string `json:"domain,omitempty"`
+	Domain string `json:"domain,omitempty" yaml:"domain,omitempty"`
 }
 
 // systemService handles communication with the system methods of the Backstage Catalog API.

--- a/backstage/kind_user.go
+++ b/backstage/kind_user.go
@@ -15,13 +15,13 @@ type UserEntityV1alpha1 struct {
 	Entity
 
 	// ApiVersion is always "backstage.io/v1alpha1".
-	ApiVersion string `json:"apiVersion"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion"`
 
 	// Kind is always "User".
-	Kind string `json:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
 
 	// Spec is the specification data describing the user itself.
-	Spec *UserEntityV1alpha1Spec `json:"spec"`
+	Spec *UserEntityV1alpha1Spec `json:"spec" yaml:"spec"`
 }
 
 // UserEntityV1alpha1Spec describes the specification data describing the user itself.
@@ -32,19 +32,19 @@ type UserEntityV1alpha1Spec struct {
 	// fetch and render on a profile page or similar.
 	Profile struct {
 		// DisplayName is a simple display name to present to users.
-		DisplayName string `json:"displayName,omitempty"`
+		DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 
 		// Email where this user can be reached.
-		Email string `json:"email,omitempty"`
+		Email string `json:"email,omitempty" yaml:"email,omitempty"`
 
 		// Picture is a URL of an image that represents this user.
-		Picture string `json:"picture,omitempty"`
-	} `json:"profile,omitempty"`
+		Picture string `json:"picture,omitempty" yaml:"picture,omitempty"`
+	} `json:"profile,omitempty" yaml:"profile,omitempty"`
 
 	// MemberOf is the list of groups that the user is a direct member of (i.e., no transitive memberships are listed here).
 	// The list must be present, but may be empty if the user is not member of any groups. The items are not guaranteed to be
 	// ordered in any particular way. The entries of this array are entity references.
-	MemberOf []string `json:"memberOf,omitempty"`
+	MemberOf []string `json:"memberOf,omitempty" yaml:"memberOf,omitempty"`
 }
 
 // userService handles communication with the user methods of the Backstage Catalog API.


### PR DESCRIPTION
This will make the Backstage structs decode fine when unMarshalling a yaml document. No functionality changed.