### PR TITLE
build(go): update Go version to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
         go-version-file: go.mod
         cache: true
     - name: Lint
-      uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v3.7.1
+      uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
       with:
-        version: v1.55
+        version: v1.61
 
   unit-test:
     name: Unit Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 output:
-  format: github-actions
+  formats:
+    - format: colored-line-number
 
 linters-settings:
   lll:

--- a/backstage/entity.go
+++ b/backstage/entity.go
@@ -216,11 +216,11 @@ func (s *entityService) List(ctx context.Context, options *ListEntityOptions) ([
 			values.Add("filter", f)
 		}
 
-		if options.Fields != nil && len(options.Fields) > 0 {
+		if len(options.Fields) > 0 {
 			values.Add("fields", strings.Join(options.Fields, ","))
 		}
 
-		if options.Order != nil && len(options.Order) > 0 {
+		if len(options.Order) > 0 {
 			for _, o := range options.Order {
 				if order, err := o.string(); err != nil {
 					return nil, nil, err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tdabasinskas/go-backstage/v2
 
-go 1.22
+go 1.23
 
 require (
 	github.com/h2non/gock v1.2.0


### PR DESCRIPTION
Upgraded the Go version specified in go.mod from 1.22 to 1.23 to ensure compatibility with the latest language features and improvements.